### PR TITLE
Based on packagemanager now

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 # tasks file for bootstrap
-- name: register release
-  raw: cat /etc/*-release
-  register: release
-  changed_when: false
+- name: register yum
+  raw: yum version
+  register: yum
+  changed_when: no
   become: no
   check_mode: no
 
@@ -25,13 +25,13 @@
     - "' installing python' in archlinux.stdout"
   remote_user: "{{ bootstrap_user }}"
 
-- name: install software on centos
+- name: install software with yum
   raw: yum -y install python2 sudo
   when:
-    - "'CentOS' in release.stdout"
-  register: centos
+    - yum.rc == 0
+  register: yum
   changed_when:
-    - "'Nothing' not in centos.stdout"
+    - "'Nothing' not in yum.stdout"
   remote_user: "{{ bootstrap_user }}"
 
 - name: install software debian

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,84 +1,107 @@
 ---
 # tasks file for bootstrap
-- name: register yum
-  raw: yum version
-  register: yum
+- name: register apk
+  raw: apk --version
+  register: apk
   changed_when: no
+  failed_when: no
   become: no
   check_mode: no
 
-- name: install software on alpine
+- name: register apt
+  raw: apt --version
+  register: apt
+  changed_when: no
+  failed_when: no
+  become: no
+  check_mode: no
+
+- name: register dnf
+  raw: dnf --version
+  register: dnf
+  changed_when: no
+  failed_when: no
+  become: no
+  check_mode: no
+
+- name: register pacman
+  raw: pacman --version
+  register: pacman
+  changed_when: no
+  failed_when: no
+  become: no
+  check_mode: no
+
+- name: register yum
+  raw: yum --version
+  register: yum
+  changed_when: no
+  failed_when: no
+  become: no
+  check_mode: no
+
+- name: register zypper
+  raw: zypper --version
+  register: zypper
+  changed_when: no
+  failed_when: no
+  become: no
+  check_mode: no
+
+- name: install software with apk
   raw: apk update ; apk add python sudo
   when:
-    - "'alpine' in release.stdout"
-  register: alpine
+    - apk.rc == 0
+  register: apkresult
   changed_when:
-    - "'Installing python' in alpine.stdout"
+    - "'Installing python' in apkresult.stdout"
   remote_user: "{{ bootstrap_user }}"
 
-- name: install software on archlinux
+- name: install software with apt
+  raw: apt-get update ; apt-get -y install python sudo
+  when:
+    - apt.rc == 0
+  register: aptresult
+  changed_when:
+    - "' 0 newly installed' not in aptresult.stdout"
+  remote_user: "{{ bootstrap_user }}"
+
+- name: install software with dnf
+  raw: dnf -y install python2 python2-dnf sudo
+  when:
+    - dnf.rc == 0
+  register: dnfresult
+  changed_when:
+    - "'Nothing' not in dnfresult.stdout"
+  remote_user: "{{ bootstrap_user }}"
+
+- name: install software with pacman
   raw: pacman -Syu ; pacman -T python sudo || pacman -S --noconfirm python sudo
   when:
-    - "'archlinux' in release.stdout"
-  register: archlinux
+    - pacman.rc == 0
+  register: pacmanresult
   changed_when:
-    - "' installing python' in archlinux.stdout"
+    - "' installing python' in pacmanresult.stdout"
   remote_user: "{{ bootstrap_user }}"
 
 - name: install software with yum
   raw: yum -y install python2 sudo
   when:
     - yum.rc == 0
-  register: yum
+  register: yumresult
   changed_when:
-    - "'Nothing' not in yum.stdout"
+    - "'Nothing' not in yumresult.stdout"
   remote_user: "{{ bootstrap_user }}"
 
-- name: install software debian
-  raw: apt-get update ; apt-get -y install python sudo
-  when:
-    - "'Debian' in release.stdout"
-  register: debian
-  changed_when:
-    - "' 0 newly installed' not in debian.stdout"
-  remote_user: "{{ bootstrap_user }}"
-
-- name: install software on fedora
-  raw: yum -y install python2 python2-dnf sudo
-  when:
-    - "'Fedora' in release.stdout"
-  register: fedora
-  changed_when:
-    - "'Nothing' not in fedora.stdout"
-  remote_user: "{{ bootstrap_user }}"
-
-- name: install software opensuse
+- name: install software with zypper
   raw: zypper -n install python python-xml sudo
   when:
-    - "'openSUSE' in release.stdout"
-  register: opensuse
+    - zypper.rc == 0
+  register: zypperresult
   changed_when:
-    - "'Nothing' not in opensuse.stdout"
+    - "'Nothing' not in zypperresult.stdout"
   remote_user: "{{ bootstrap_user }}"
   failed_when: no
-
-- name: install software on redhat
-  raw: yum -y install python2 sudo
-  when:
-    - "'Red Hat' in release.stdout"
-  register: redhat
-  changed_when:
-    - "'Nothing' not in redhat.stdout"
-  remote_user: "{{ bootstrap_user }}"
-
-- name: install software ubuntu
-  raw: apt-get update ; apt-get -y install python sudo
-  when:
-    - "'Ubuntu' in release.stdout"
-  register: ubuntu
-  changed_when:
-    - "' 0 newly installed' not in ubuntu.stdout"
-  remote_user: "{{ bootstrap_user }}"
 
 - name: gather facts
   setup:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,9 +8,9 @@
   become: no
   check_mode: no
 
-- name: register apt
-  raw: apt --version
-  register: apt
+- name: register apt_get
+  raw: apt-get --version
+  register: apt_get
   changed_when: no
   failed_when: no
   become: no
@@ -57,13 +57,13 @@
     - "'Installing python' in apkresult.stdout"
   remote_user: "{{ bootstrap_user }}"
 
-- name: install software with apt
+- name: install software with apt-get
   raw: apt-get update ; apt-get -y install python sudo
   when:
-    - apt.rc == 0
-  register: aptresult
+    - apt_get.rc == 0
+  register: apt_getresult
   changed_when:
-    - "' 0 newly installed' not in aptresult.stdout"
+    - "' 0 newly installed' not in apt_getresult.stdout"
   remote_user: "{{ bootstrap_user }}"
 
 - name: install software with dnf


### PR DESCRIPTION
Instead of /etc/*-release the selection for package manager is now based on what package manager is available. Quite logical actually.

Fixes #4.