### PR TITLE
Don't become when delegating to localhost

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     port: "{{ ansible_port | default('22') }}"
     host: "{{ inventory_hostname }}"
   delegate_to: localhost
+  become: no
   when:
     - inventory_hostname is defined
     - ansible_connection is defined


### PR DESCRIPTION
---
name: Pull request
about: When waiting for the host to become available, it is not necessary to have elevated privileges.

---

**Describe the change**
This pull request adds a fix to not become root when running the wait_for task that checks ssh port availability.

**Testing**
I tested this change as part of my molecule setup. The previous error where my prepare playbook failed with "sudo: password required", now works.
