### PR TITLE
Update vars/main.yml

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -23,8 +23,10 @@ _bootstrap_packages:
   Kali GNU/Linux: python3 sudo gnupg
   openSUSE: python python-xml sudo
   openSUSE Leap: python python-xml sudo
-  Red Hat Enterprise Linux-7: python3 sudo
-  Red Hat Enterprise Linux: python3 sudo
+  RedHat: python3 sudo
+  RedHat-7: python3 sudo
+  Red Hat Enterprise Linux Server-7: python3 sudo
+  Red Hat Enterprise Linux Server: python3 sudo
   Ubuntu: python3 sudo gnupg
 
 # Map the right set of package based on values found in `tasks/register.yml`.


### PR DESCRIPTION
bootstrap_packages  fails on rhel7 because `Red Hat Enterprise Linux` should be `Red Hat Enterprise Linux Server` when  reading from  /etc/redhat-release
bootstrap_facts_packages fails on rhel7 because `ansible_distribution=RedHat`  does not match 'Red Hat Enterprise Linux 'or 'Red Hat Enterprise Linux-7'  in _bootstrap_packages

---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
A clear and concise description of what the pull request is.

**Testing**
In case a feature was added, how were tests performed?
