### PR TITLE
Add python3-lxml to CentOS 8 and RedHat 8

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,12 +4,13 @@
 _bootstrap_packages:
   Alpine: python3 sudo
   Archlinux: python sudo
-  Debian: python3 sudo gnupg python3-apt
+  Debian: python3 sudo gnupg python3-apt python3-lxml
   Gentoo: python sudo gentoolkit
   RedHat: python3 sudo
   Suse: python3 python3-xml sudo
   Amazon: python sudo
   CentOS_7: python sudo
+  CentOS_8: python3-lxml
   Debian_8: python sudo gnupg
   Debian_9: python sudo gnupg
   RedHat_7: python sudo

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,7 +6,7 @@ _bootstrap_packages:
   Archlinux: python sudo
   Debian: python3 sudo gnupg python3-apt python3-lxml
   Gentoo: python sudo gentoolkit
-  RedHat: python3 sudo
+  RedHat: python3 python-lxml sudo
   Suse: python3 python3-xml sudo
   Amazon: python sudo
   CentOS_7: python sudo


### PR DESCRIPTION
---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
I see CentOS8 / RHEL8 needs python3-lxml.
