### PR TITLE
Don't become, not variable user.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,6 @@
 ---
 # defaults file for bootstrap
 
-# The user to use to connect to machines.
-bootstrap_user: root
-
 # Do you want to wait for the host to be available?
 bootstrap_wait_for_host: no
 

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -8,10 +8,6 @@ argument_specs:
       This role tries to figure out what to install and uses the raw module to install the packages.
     author: Robert de Bock
     options:
-      bootstrap_user:
-        type: "str"
-        default: root
-        description: "The username to use to connect to machines."
       bootstrap_wait_for_host:
         type: "bool"
         default: no

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,7 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  become: yes
+  become: no
   gather_facts: no
 
   roles:

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -1,12 +1,5 @@
 ---
 
-- name: test if bootstrap_user is set correctly
-  ansible.builtin.assert:
-    that:
-      - bootstrap_user is defined
-      - bootstrap_user is string
-    quiet: yes
-
 - name: test if bootstrap_wait_for_host is set correctly
   ansible.builtin.assert:
     that:

--- a/tasks/gather_facts.yml
+++ b/tasks/gather_facts.yml
@@ -1,13 +1,11 @@
 ---
 
 - name: lookup bootstrap facts
-  become: no
   ansible.builtin.raw: "cat /etc/os-release"
+  become: no
   check_mode: no
   register: bootstrap_facts
   changed_when: no
-  vars:
-    ansible_user: "{{ bootstrap_user }}"
 
 - name: set bootstrap facts (I)
   ansible.builtin.set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,12 +6,13 @@
   run_once: yes
   delegate_to: localhost
 
-- name: wait for host
+- name: wait for port to be available
   ansible.builtin.wait_for:
     port: "{{ ansible_port | default('22') }}"
-    host: "{{ (ansible_ssh_host | default(ansible_host) | default(inventory_hostname)) }}"
-  connection: local
-  become: no
+    timeout: "{{ bootstrap_timeout }}"
+    # host: "{{ ansible_ssh_host | default(ansible_host) | default(inventory_hostname) }}"
+  # connection: local
+  # become: no
   when:
     - ansible_connection is defined
     - ansible_connection not in [ "container", "docker", "community.docker.docker" ]
@@ -37,21 +38,6 @@
            bootstrap_os_family in [ "Alpine", "Archlinux", "Gentoo" ]) or
           (bootstrap_install.stdout_regex not in bootstrap_install_packages.stdout and
            bootstrap_os_family in [ "Debian", "RedHat", "Rocky", "Suse" ])
-      vars:
-        ansible_user: "{{ bootstrap_user }}"
-  always:
-    - name: set bootstrap_ansible_user connected
-      ansible.builtin.set_fact:
-        bootstrap_ansible_user: "{{ ansible_user }}"
-      when:
-        - bootstrap_connect is succeeded
-        - ansible_user is defined
-
-    - name: set bootstrap_ansible_user not connected
-      ansible.builtin.set_fact:
-        bootstrap_ansible_user: "{{ bootstrap_user }}"
-      when:
-        - bootstrap_connect is failed
 
 - name: ensure system is prepared
   block:
@@ -63,5 +49,3 @@
         name: "{{ item }}"
         state: present
       loop: "{{ bootstrap_facts_packages.split() }}"
-  vars:
-    ansible_user: "{{ bootstrap_ansible_user | default(omit) }}"


### PR DESCRIPTION
---
name: Pull request
about: Simpler, no variable user, it's always root anyway.

---

**Describe the change**
There was a variable to set the remote user, but packages always need to be installed with the root-user.

**Testing**
Molecule in CI.