### PR TITLE
fix #59

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ This example is taken from `molecule/default/converge.yml` and is tested on each
 ---
 - name: Converge
   hosts: all
-  # This role installs packages using the `raw` module and needs to connect as
-  # `root`. (`sudo` is not available before bootstrapping.) All tasks in the
-  # role have `become` set to `no`, so you can use either `no` or `yes` for
-  # `become`, the role will not use become (so `sudo`) for any task.
+  # This role installs packages using the `raw` module and connects as
+  # `root` per default. (`sudo` is sometimes not available before bootstrapping.) 
+  # All relevant tasks in the role have `become` set per default to `no`, so you can
+  # use either `no` or `yes` for `become`, the role will not use become (so `sudo`) for # any relevant task. Use `bootstrap_not_as_root` to override that behaviour.
   become: yes  # `no` will also work.
   # This role installs python, gathering facts can't be done before `python` is
   # installed. This role runs the `setup` module, so facts will be available
@@ -25,6 +25,7 @@ This example is taken from `molecule/default/converge.yml` and is tested on each
 
   roles:
     - role: robertdebock.bootstrap
+      # bootstrap_not_as_root: True
 ```
 
 Also see a [full explanation and example](https://robertdebock.nl/how-to-use-these-roles.html) on how to use these roles.
@@ -35,6 +36,9 @@ The default values for the variables are set in `defaults/main.yml`:
 ```yaml
 ---
 # defaults file for bootstrap
+
+# Allow to bootstrap as non root ( e.g. vagrant user )
+bootstrap_not_as_root: no
 
 # Do you want to wait for the host to be available?
 bootstrap_wait_for_host: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 # defaults file for bootstrap
 
+# Allow to bootstrap as non root ( e.g. vagrant user )
+bootstrap_not_as_root: no
+
 # Do you want to wait for the host to be available?
 bootstrap_wait_for_host: no
 

--- a/tasks/gather_facts.yml
+++ b/tasks/gather_facts.yml
@@ -2,7 +2,6 @@
 
 - name: lookup bootstrap facts
   ansible.builtin.raw: "cat /etc/os-release"
-  become: no
   check_mode: no
   register: bootstrap_facts
   changed_when: no
@@ -17,7 +16,6 @@
     - bootstrap_facts.rc == 0
     - bootstrap_distribution is not defined
     - bootstrap_facts.stdout is regex('PRETTY_NAME=.'~ bootstrap_search[item] | default(item) ~'.*')
-  become: no
 
 - name: set bootstrap facts (II)
   ansible.builtin.set_fact:
@@ -27,4 +25,3 @@
     label: "{{ item.key }}"
   when:
     - bootstrap_distribution in item.value
-  become: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   ansible.builtin.wait_for:
     port: "{{ ansible_port | default('22') }}"
     timeout: "{{ bootstrap_timeout }}"
-  become: no
+  become: "{{ bootstrap_not_as_root | default(False) | bool }}"
   when:
     - ansible_connection is defined
     - ansible_connection not in [ "container", "docker", "community.docker.docker" ]
@@ -36,7 +36,7 @@
            bootstrap_os_family in [ "Alpine", "Archlinux", "Gentoo" ]) or
           (bootstrap_install.stdout_regex not in bootstrap_install_packages.stdout and
            bootstrap_os_family in [ "Debian", "RedHat", "Rocky", "Suse" ])
-  become: no
+  become: "{{ bootstrap_not_as_root | default(False) | bool }}"
 
 
 - name: ensure system is prepared
@@ -49,4 +49,4 @@
         name: "{{ item }}"
         state: present
       loop: "{{ bootstrap_facts_packages.split() }}"
-  become: no
+  become: "{{ bootstrap_not_as_root | default(False) | bool }}"


### PR DESCRIPTION
---
name: Pull request
about: Describe the proposed change

---

**Describe the change**

Introduces `bootstrap_not_as_root` variable default no, which allows to run this role on hosts which have no root user available.

**Testing**

Local but if required and allowed a molecule scenario could be added for vanilla fedora/centos image.
