### PR TITLE
Add support for bootstrapping FreeBSD hosts

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,6 +25,9 @@ galaxy_info:
     - name: Fedora
       versions:
         - all
+    - name: FreeBSD
+      versions:
+        - 13
     - name: OpenSUSE
       versions:
         - all

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
       register: bootstrap_install_packages
       changed_when:
         - (bootstrap_install.stdout_regex in bootstrap_install_packages.stdout and
-           bootstrap_os_family in [ "Alpine", "Archlinux", "Gentoo" ]) or
+           bootstrap_os_family in [ "Alpine", "Archlinux", "FreeBSD", "Gentoo" ]) or
           (bootstrap_install.stdout_regex not in bootstrap_install_packages.stdout and
            bootstrap_os_family in [ "Debian", "RedHat", "Rocky", "Suse" ])
   become: no

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,6 +5,7 @@ _bootstrap_packages:
   Alpine: python3 sudo
   Archlinux: python sudo
   Debian: python3 sudo gnupg python3-apt
+  FreeBSD: python sudo
   Gentoo: python sudo gentoolkit
   RedHat: &redhat_packages python3 sudo
   Suse: python3 python3-xml sudo
@@ -29,6 +30,9 @@ _bootstrap_install:
   Debian:
     raw: "LANG=C apt-get update && apt-get install -y {{ bootstrap_packages }}"
     stdout_regex: ' 0 newly installed'
+  FreeBSD:
+    raw: "env LANG=C pkg install -y {{ bootstrap_packages }}"
+    stdout_regex: 'New packages to be INSTALLED'
   Gentoo:
     raw: "LANG=C equery l {{ bootstrap_packages }} ||
           (emaint -a sync ; emerge -qkv {{ bootstrap_packages }} ; echo 'changed')"
@@ -53,6 +57,7 @@ bootstrap_os_family_map:
   Debian: [Debian, Ubuntu, Raspbian, Neon, KDE neon,
            Linux Mint, SteamOS, Devuan, Kali, Cumulus Linux,
            'Pop!_OS', Parrot, Pardus GNU/Linux]
+  FreeBSD: [FreeBSD]
   Gentoo: [Gentoo, Funtoo]
   RedHat: [RedHat, Fedora, CentOS, Scientific, SLC,
            Ascendos, CloudLinux, PSBM, Rocky, OracleLinux,


### PR DESCRIPTION
Add support for bootstrapping FreeBSD hosts.

Tested working with FreeBSD 13.0, which is the first version where `/etc/os-release` was introduced.

For the moment it is not easy to add a github action to test this: there is no native support for FreeBSD images in github actions.