### PR TITLE
Make role compatible with Podman

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,8 @@
 
     - name: install bootstrap packages (raw)
       ansible.builtin.raw: "{{ bootstrap_install.raw }}"
+      args:
+        executable: /bin/sh
       register: bootstrap_install_packages
       changed_when:
         - (bootstrap_install.stdout_regex in bootstrap_install_packages.stdout and


### PR DESCRIPTION
---
name: Make role compatible with Podman
about: See below

---

**Describe the change**
This patch passes the `raw` command to install packages through `/bin/sh`. Otherwise, when running this role against a podman container using the podman connection plugin, podman tries to find an executable in the `$PATH` named `LANG=C` and fails.

**Testing**
In case a feature was added, how were tests performed?

I tested this using `molecule test` with the following patch applied to `molecule/default/molecule.yml`

``` patch
diff --git a/molecule/default/molecule.yml b/molecule/default/molecule.yml
index 1e24c87..af08020 100644
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,14 +12,11 @@ lint: |
   yamllint .
   ansible-lint
 driver:
-  name: docker
+  name: podman
 platforms:
   - name: "bootstrap-${image:-fedora}-${tag:-latest}${TOX_ENVNAME}"
     image: "${namespace:-robertdebock}/${image:-fedora}:${tag:-latest}"
     command: /sbin/init
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: yes
     pre_build_image: yes
 provisioner:
   name: ansible
``` 
