### PR TITLE
Install packages with sudo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,4 +49,4 @@
         name: "{{ item }}"
         state: present
       loop: "{{ bootstrap_facts_packages.split() }}"
-  become: no
+  become: yes


### PR DESCRIPTION
Change "install bootstrap packages (package)" task to become: yes so that packages can be installed successfully. Need sudo/become. There was a PR about this but it was closed and wasn't clear why. I tested this change out on RHEL 8 and it worked.

---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
A clear and concise description of what the pull request is.

**Testing**
In case a feature was added, how were tests performed?
