### PR TITLE
fix(vars): gnupg2 package for Debian 10+

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,6 +12,9 @@ _bootstrap_packages:
   CentOS_7: python sudo
   Debian_8: python sudo gnupg
   Debian_9: python sudo gnupg
+  Debian_10: python3 sudo gnupg2
+  Debian_11: python3 sudo gnupg2
+  Debian_12: python3 sudo gnupg2
   RedHat_7: python sudo
 
 # Map the right set of packages, based on gathered bootstrap facts.


### PR DESCRIPTION
---
name: Replace gnupg with gnupg2 for Debian 10+
about: Package gnupg is no longer available starting at Debian 10 (buster)

---

**Describe the change**
Replaces gnupg with gnupg2

