### PR TITLE
fix: add ucs to bootstrap packages

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,6 +17,7 @@ _bootstrap_packages:
   Debian_12: python3 sudo gnupg2
   RedHat_7: python sudo
   Fedora: python3 sudo python3-libdnf5 python3-rpm
+  'Univention Corporate Server': python3 sudo gnupg python3-apt
 
 # Map the right set of packages, based on gathered bootstrap facts.
 bootstrap_packages: "{{ _bootstrap_packages[bootstrap_distribution ~'_'~ bootstrap_distribution_major_version]|default(


### PR DESCRIPTION
Hi again,

Sorry, this is a follow up for #76. UCS also needs to be added to the `_bootstrap_packages` 
