### PR TITLE
fix deprecation warning

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,10 +19,9 @@ _bootstrap_packages:
   Fedora: python3 sudo python3-libdnf5 python3-rpm
   'Univention Corporate Server': python3 sudo gnupg python3-apt
 
-# Map the right set of packages, based on gathered bootstrap facts.
-bootstrap_packages: "{{ _bootstrap_packages[bootstrap_distribution ~'_'~ bootstrap_distribution_major_version]|default(
-                     _bootstrap_packages[bootstrap_distribution] )|default(
-                     _bootstrap_packages[bootstrap_os_family] ) }}"
+bootstrap_facts_packages: "{{ _bootstrap_packages[ansible_facts['distribution'] ~'_'~ ansible_facts['distribution_major_version']]|default(
+                           _bootstrap_packages[ansible_facts['distribution']] )|default(
+                           _bootstrap_packages[ansible_facts['os_family']] ) }}"
 
 _bootstrap_install:
   Alpine:


### PR DESCRIPTION
Hi,

this fixes:

```bash
TASK [robertdebock.bootstrap : Install bootstrap packages (package)] **********************************************************************************************************************
[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
Origin: /home/ansible-dev/.ansible/roles/robertdebock.bootstrap/vars/main.yml:75:27

73
74 # Map the right set of packages, based on gathered ansible_facts.
75 bootstrap_facts_packages: "{{ _bootstrap_packages[ansible_distribution ~'_'~ ansible_distribution_major_version]|d...
                             ^ column 27

Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```