### PR TITLE
update to prevent INJECT_FACTS_AS_VARS deprecation

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -70,6 +70,6 @@ bootstrap_search:
   RedHat: 'Red Hat'
 
 # Map the right set of packages, based on gathered ansible_facts.
-bootstrap_facts_packages: "{{ _bootstrap_packages[ansible_distribution ~'_'~ ansible_distribution_major_version]|default(
-                           _bootstrap_packages[ansible_distribution] )|default(
-                           _bootstrap_packages[ansible_os_family] ) }}"
+bootstrap_facts_packages: "{{ _bootstrap_packages[ansible_facts['distribution'] ~'_'~ ansible_facts['distribution_major_version']]|default(
+                           _bootstrap_packages[ansible_facts['distribution']] )|default(
+                           _bootstrap_packages[ansible_facts['os_family']] ) }}"


### PR DESCRIPTION
---
name: update to prevent INJECT_FACTS_AS_VARS deprecation
about: INJECT_FACTS_AS_VARS deprecation

---

**Describe the change**

To fix the deprecation warning below. Usages were replaced accordingly.

```
TASK [robertdebock.bootstrap : Install bootstrap packages (package)] ***********
[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
Origin: robertdebock.bootstrap/vars/main.yml:75:27
73
74 # Map the right set of packages, based on gathered ansible_facts.
75 bootstrap_facts_packages: "{{ _bootstrap_packages[ansible_distribution ~'_'~ ansible_distribution_major_version]|d...
                            ^ column 27
Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```

**Testing**
N/A
